### PR TITLE
Fix: update Events Page link in sidebar (PR)

### DIFF
--- a/_tabs/our user group.md
+++ b/_tabs/our user group.md
@@ -132,7 +132,7 @@ These activities are designed to benefit everyone—from novices to experts—wh
 - [DevOps Visions Facebook](https://www.facebook.com/vsalmplanet)
 
 ### Events & Highlights
-- [Events Page](/user-group-events/)
+- [Events Page](https://devopsvisions.github.io/blog/user-group-events/)
 - [Featured Posts](/)
 
 


### PR DESCRIPTION
Fixed issue of updating events page link from:  /user-group-events/
to: https://devopsvisions.github.io/blog/user-group-events/ 

SHA-1: fe6d6844e593b5635e3b5bc0934c99800c44c1d5
@aymanaboghonim Please review this PR, Thanks.
<img width="1804" height="1221" alt="Screenshot 2025-07-20 073546" src="https://github.com/user-attachments/assets/99dae709-ebef-4104-a98b-802cc19c7044" />

