### PR TITLE
feat: add YouTube link for Career Guidance session with Karim

### DIFF
--- a/_tabs/user group events.md
+++ b/_tabs/user group events.md
@@ -57,7 +57,7 @@ A community-wide Career Guidance Session will be arranged in collaboration with 
 - **🌐 Language:** Arabic   
 - **🎞️ Record available on:**  
    - [Facebook Event](https://www.facebook.com/share/16i5zPMTZe/)  
-   - [YouTube Video](https://www.youtube.com/@MRadwanMSF/videos)
+   - [YouTube Video](https://www.youtube.com/watch?v=bwY4QYxJy5w&ab_channel=MohamedRadwan%28EG%29)
 
 - **🏷️ Tags:** `career guidance` `mentorship` `professional development`
 


### PR DESCRIPTION
## Overview
This PR addresses issue #6 by adding YouTube link for Career Guidance session with Karim **Events** page.

## Changes Made
- **File Modified:** `_tabs/user group events.md`  
- **Link Added:** YouTube link for Career Guidance session with Karim

## References
- #6 
- **Branch:** `feature/career-guidance-session-link`  
- Independent implementation (no dependencies on other PRs)