### PR TITLE
feat: Update views count for AI-Augmented DevOps Loop event

### DIFF
--- a/_tabs/user group events.md
+++ b/_tabs/user group events.md
@@ -15,7 +15,7 @@ streamlining the developer inner loop. http://elmentorprogram.com/
 
 - **📅 Date:** Dec 17, 2025
 - **🗣️ Speakers:** [Mohamed Radwan](https://mohamedradwan.com/), [Ayman Aboghonim](https://github.com/aymanaboghonim)
-- **👁️ Views:** Upcoming Event
+- **👁️ Views:** 400
 - **💻 Streamed Live on:** Linkedin
 - **🌐 Language:** English
 - **🎞️ Record available on:**


### PR DESCRIPTION

## Overview
This PR addresses issue #13 by updating the views count of the AI-Augmented DevOps Loop in **Events** page.

## Changes Made
- **File Modified:** `_tabs/user group events.md`
- **Modifications Done:**  Replace the placeholder "Upcoming Event" with the actual views count in the user group events tab (_tabs/user group events.md) for the AI-Augmented DevOps Loop event.

## References
-  #13 
- **Branch:**  `feat/add-session-views`
- Independent implementation (no dependencies on other PRs)