### PR TITLE
feat: Add YouTube link for DORA session

### DIFF
--- a/_tabs/user group events.md
+++ b/_tabs/user group events.md
@@ -58,7 +58,7 @@ A public discussion session analyzing the new DORA report 2025 (Impact of Genera
 - **🌐 Language:** Arabic   
 - **🎞️ Record available on:**  
    - [Facebook Event](https://www.facebook.com/share/19M6GbMjKX/)  
-   - [YouTube Video](https://www.youtube.com/@MRadwanMSF/videos)
+   - [YouTube Video](https://www.youtube.com/watch?v=mk-6QnHf5Qw)
 
 - **🏷️ Tags:** `DORA` `AI` `software development`
 


### PR DESCRIPTION
## Overview
This PR addresses issue #10 by adding YouTube link for DORA session in **Events** page.

## Changes Made
- **File Modified:**  `_tabs/user group events.md`
- **Link Added:**  Add the YouTube session link

## References
-  #10 
- **Branch:**  `feat/dora-session-link`
- Independent implementation (no dependencies on other PRs)